### PR TITLE
coq-mi-cho-coq: Add missing dependency to ocamlbuild

### DIFF
--- a/extra-dev/packages/coq-mi-cho-coq/coq-mi-cho-coq.dev/opam
+++ b/extra-dev/packages/coq-mi-cho-coq/coq-mi-cho-coq.dev/opam
@@ -15,6 +15,7 @@ install: [
   make "install"
 ]
 depends: [
+  "ocamlbuild"
   "coq-menhirlib" {>= "20190626"}
   "coq-ott" {>= "0.29"}
   "coq" {>= "8.8"}


### PR DESCRIPTION
Dependency to ocamlbuild was missing in package coq-mi-cho-coq.